### PR TITLE
remove default call to setup

### DIFF
--- a/lua/dotnet/init.lua
+++ b/lua/dotnet/init.lua
@@ -128,6 +128,4 @@ M.setup = function(opts)
 
 end
 
-M.setup (M.opts)
-
 return M


### PR DESCRIPTION
This call seems to be an oversight. It ends up creating the bootstrap autocmd regardless of the user's bootstrap setting, because it's being called with the default opts. 