### PR TITLE
Allow nil argument to setup method

### DIFF
--- a/lua/dotnet/init.lua
+++ b/lua/dotnet/init.lua
@@ -25,7 +25,7 @@ local M = {
 
 local function _process_user_opts(opts)
 
-	require('dotnet.utils.nvim-utils').merge_tables(M.opts, opts)
+	require('dotnet.utils.nvim-utils').merge_tables(M.opts, opts or {})
 
 	return M.opts
 end


### PR DESCRIPTION
This is just a small quality of life improvement, inspired by my own confusion as to why i got errors when using the plugin. :)

With this change the setup function should behave the same if nil or an empty table is supplied.